### PR TITLE
Fix: Update DOM identifier for amazon_discount_price' on detail page

### DIFF
--- a/src/contents/App.vue
+++ b/src/contents/App.vue
@@ -415,8 +415,8 @@ export default {
                     continue;
                 } else if (target.name === "amazon_discount_price") {
                   if (
-                    document.getElementById("corePrice_desktop") === null ||
-                    document.getElementById("corePrice_desktop").innerText ===
+                    document.getElementById("corePrice_feature_div") === null ||
+                    document.getElementById("corePrice_feature_div").innerText ===
                       ""
                   )
                     continue;
@@ -642,6 +642,13 @@ export default {
             );
           }
         } else if (this.website === "Amazon") {
+          // Add these debug logs
+          console.log("Checking Amazon elements:");
+          console.log("Buy Now button exists:", document.getElementById("submit.buy-now"));
+          console.log("ccorePrice_feature_div exists:", document.getElementById("corePrice_feature_div"));
+          console.log("Elements with id starting with corePrice_desktop:", document.querySelectorAll('[id^=corePrice_desktop]').length);
+          console.log("Elements with id starting with apex_desktop:", document.querySelectorAll('[id^=apex_desktop]').length);
+
           if (this.targetIdentifiers[i] === "submit.buy-now") {
             element = document.getElementById(this.targetIdentifiers[i]);
           } else if (
@@ -809,7 +816,7 @@ export default {
         }
       }
 
-      console.log("Got new list of bounding boxes");
+      console.log("Got new list of bounding boxes :>");
       console.log(this.boundingBoxList);
     },
     refresh() {

--- a/src/contents/index.js
+++ b/src/contents/index.js
@@ -102,8 +102,8 @@ export default {
     },
     {
       name: "amazon_discount_price",
-      identifier: "corePrice_desktop",
-      url: "www.amazon.com(\\S*)/dp",
+      identifier: "corePriceDisplay_desktop_feature_div",
+      url: "www.amazon.com(\\S*)((/dp)|(/gp))",
       type: "online shopping platform",
       tag: ["information hiding"],
       icon:


### PR DESCRIPTION
This PR updates the identifier used to detect the discount_price function on Amazon detail pages. Amazon’s DOM has changed, and the previous selector no longer works, causing the panel not to show up.

I’m currently studying dark patterns as part of a course project, and your extension has been very helpful as an example. While using it, I noticed some patterns no longer activate, so I wanted to contribute a fix to help maintain the project.

Let me know if there’s anything else I can improve—thank you for this great work!

